### PR TITLE
Bouton de réinitialisation de la signature

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
         <label for="date">&nbsp;le </label><input type="date" id="date"><br>
         (signature)<br/><br/>
         <canvas style="border: 1px solid #999" id="signature" width="600" height="200"></canvas><br/>
-        <button onclick="can_clear();" id="clear_btn">Effacer</button>
+        <button type="button" onclick="can_clear();" id="clear_btn">Effacer</button>
 
     </p>
 


### PR DESCRIPTION
Lorsque l'on clique sur le bouton pour reset la signature, tout le formulaire est submit et donc cela reset tout, ce qui n'est pas le comportement souhaité.

Lié au fait que le bouton n'a pas de type spécifié et donc le formulaire le traite comme un submit.

Reproduit sur Chrome et Firefox.